### PR TITLE
Add missing lxml setup.py requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name="helga-newrelic",
       packages=find_packages(),
       install_requires = [
           'requests==2.2.1',
+          'lxml>=3',
       ],
       entry_points = dict(
           helga_plugins=[


### PR DESCRIPTION
setup.py is missing the lxml requirement for plugins.py; this adds it
